### PR TITLE
refactor: power all functions off shared environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+
+name: test
+
+on:
+  push:
+    branches:
+      - "**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use NodeJS ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i
+      - run: npm test
+        env:
+          CI: true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
 - *string* `bump-to` **Required**: the semver comptaible version to bump to
 - *string* `package` **Optional**: the package name that contains the files to bump. Great for repos with multiple independently versioned packages ie. in a monorepo. Example: `app-opine` will find a package in `*/**/app-opine`
 - *string* `prefix` **Optional**: prefix to use for the git tag. Example: `app-opine` prefix and `v1.3.2` version will result in a tag of `app-opine@v1.3.2`. **default**: the `package` input.
-- *string* `runtime` **Optional**: the runtime for the package: This dictates which manifest files are bumped. `egg.json` , `package.json` and `package-lock.json` for `node` or `deno`. Currently supports `node`, `deno`, or `javascript`. **default**: `deno`
+- *string* `runtime` **Optional**: the runtime for the package: This dictates which manifest files are bumped. `egg.json` , `package.json` and `package-lock.json` for `node` or `deno`. Currently supports `node`, `deno`, or `javascript`. **default**: `javascript`
 
 ### Outputs
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -124,8 +124,7 @@ function lib ({
   }
 
   async function getPackage (
-    pkg,
-    runtime
+    pkg
   ) {
     let paths = await globby(`*/**/${pkg}`, {
       onlyDirectories: true
@@ -138,9 +137,14 @@ function lib ({
    * contain a manifest file at the root of the directory
    */
     if (paths.length > 1) {
-      paths = paths.filter(path => existsSync(
-        join(path, runtime === 'deno' ? DENO_MANIFEST : NODE_MANIFEST)
-      ))
+      paths = paths.filter(path =>
+        existsSync(
+          join(path, DENO_MANIFEST)
+        ) ||
+        existsSync(
+          join(path, NODE_MANIFEST)
+        )
+      )
     }
 
     /**
@@ -75461,7 +75465,7 @@ const core = __nccwpck_require__(2186)
 
 const { run } = __nccwpck_require__(5496)()
 
-run.catch(err => core.setFailed(err.message))
+run().catch(err => core.setFailed(err.message))
 
 })();
 

--- a/index.js
+++ b/index.js
@@ -3,4 +3,4 @@ const core = require('@actions/core')
 
 const { run } = require('./main')()
 
-run.catch(err => core.setFailed(err.message))
+run().catch(err => core.setFailed(err.message))

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 const core = require('@actions/core')
 
-const { run } = require('./main')
+const { run } = require('./main')()
 
-run().catch(err => core.setFailed(err.message))
+run.catch(err => core.setFailed(err.message))

--- a/main.js
+++ b/main.js
@@ -118,8 +118,7 @@ function lib ({
   }
 
   async function getPackage (
-    pkg,
-    runtime
+    pkg
   ) {
     let paths = await globby(`*/**/${pkg}`, {
       onlyDirectories: true
@@ -132,9 +131,14 @@ function lib ({
    * contain a manifest file at the root of the directory
    */
     if (paths.length > 1) {
-      paths = paths.filter(path => existsSync(
-        join(path, runtime === 'deno' ? DENO_MANIFEST : NODE_MANIFEST)
-      ))
+      paths = paths.filter(path =>
+        existsSync(
+          join(path, DENO_MANIFEST)
+        ) ||
+        existsSync(
+          join(path, NODE_MANIFEST)
+        )
+      )
     }
 
     /**

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -39,10 +39,7 @@ test('it should produce the correct package', async t => {
     core
   })
 
-  const res = await getPackage(
-    mockedPath,
-    'deno'
-  )
+  const res = await getPackage(mockedPath)
 
   t.assert(mockedPath, res)
 })
@@ -59,10 +56,7 @@ test('it should produce the correct package from multiple', async t => {
     core
   })
 
-  const res = await getPackage(
-    'foo',
-    'deno'
-  )
+  const res = await getPackage('foo')
 
   t.assert(mockedPath, res)
 })
@@ -76,10 +70,7 @@ test('it should throw an error if more than one package is found', async t => {
     core
   })
 
-  await getPackage(
-    'foo',
-    'deno'
-  )
+  await getPackage('foo')
     .then(() => t.fail())
     .catch(err => t.ok(err))
 })
@@ -91,10 +82,7 @@ test('it should throw an error if no package is found', async t => {
     core
   })
 
-  await getPackage(
-    'foo',
-    'deno'
-  )
+  await getPackage('foo')
     .then(() => t.fail())
     .catch(err => t.ok(err))
 })


### PR DESCRIPTION
just refactoring all functions to run off of a shared environment, as opposed to each being passed environment as args. Just a bit cleaner and extensible.

No functional changes.